### PR TITLE
refactor: replace emma references with alter_ego

### DIFF
--- a/main/README.md
+++ b/main/README.md
@@ -1,5 +1,3 @@
-# Note: The files have yet to be properly renamed at this time. Anything that is "emma_*.py" will be renamed "alter_ego_*.py", so dont @ me!
-
 # Alter/Ego
 
 **Alter/Ego** is a fully local, emotionally intelligent assistant tailored for systems, plurals, and neurodivergent users. It listens deeply, speaks with nuanced tone, and reflects through symbolic memory. Built to honor multiplicity and adaptive identity.

--- a/main/alter_ego_computer.py
+++ b/main/alter_ego_computer.py
@@ -74,7 +74,7 @@ DEFAULT_PALETTE = "eden_moonlit"
 # --------- Config schema ----------
 class Config(BaseModel):
     data_dir: str = "./data"
-    db_dir: str = "./emma_db"
+    db_dir: str = "./alter_ego_db"
     palette: str = DEFAULT_PALETTE
     embed_model_name: str = "all-MiniLM-L6-v2"
     llm_backend: str = "transformers"  # transformers | gpt4all | ollama
@@ -83,9 +83,9 @@ class Config(BaseModel):
     chunk_chars: int = 1200
     chunk_overlap: int = 200
     collections: Dict[str, str] = {
-        "docs": "emma_docs",
-        "mem": "emma_memories",
-        "states": "emma_state_notes",
+        "docs": "alter_ego_docs",
+        "mem": "alter_ego_memories",
+        "states": "alter_ego_state_notes",
     }
     allowed_exts: List[str] = [
         ".txt", ".md", ".rst", ".py", ".js", ".ts", ".json", ".yaml", ".yml",
@@ -242,7 +242,7 @@ class LLM:
 
 # --------- Core RAG flow ----------
 SYSTEM_VIBE = (
-    "You are Emma’s Computer. Supportive, precise, and emotionally aware. "
+    "You are Alter/Ego. Supportive, precise, and emotionally aware. "
     "You use the memorybank to recall facts. If the user seems overwhelmed, you slow down, "
     "offer micro-steps, and ask gentle consent questions. Be concise. No hallucinations."
 )
@@ -252,7 +252,7 @@ def make_prompt(context_chunks: List[str], question: str) -> str:
     return f"""[system]
 {SYSTEM_VIBE}
 
-[context from Emma’s files and memories]
+[context from Alter/Ego's files and memories]
 {ctx}
 
 [instruction]
@@ -262,7 +262,7 @@ End with a one-line check-in if emotional load seems high.
 [question]
 {question}
 
-[answer as Emma’s Computer]
+[answer as Alter/Ego]
 """
 
 def retrieve_context(bank: MemoryBank, embedder: Embedder, query: str, top_k: int) -> List[str]:
@@ -486,7 +486,7 @@ def suggest_upgrades(cfg: Config, bank: MemoryBank) -> List[str]:
 
     # backups
     if not Path(cfg.db_dir, "BACKUP").exists():
-        suggestions.append("No DB backup detected. Consider `rsync -a emma_db/ emma_db/BACKUP/` weekly.")
+        suggestions.append("No DB backup detected. Consider `rsync -a alter_ego_db/ alter_ego_db/BACKUP/` weekly.")
 
     # memories presence
     try:
@@ -507,17 +507,17 @@ def palette(cfg: Config):
 def banner(cfg: Config):
     pal = palette(cfg)
     console.print(Panel.fit(
-        "[b]Emma’s Computer[/b]\nLocal RAG • MemoryDB • Dupe Scanner • Upgrades",
+        "[b]Alter/Ego[/b]\nLocal RAG • MemoryDB • Dupe Scanner • Upgrades",
         title="[b]Paradigm Eden[/b]", border_style=pal["accent"])
     )
 
 @app.command()
 def init(
     data: str = typer.Option("./data", help="Folder to ingest/watch"),
-    db: str = typer.Option("./emma_db", help="ChromaDB persistence dir"),
+    db: str = typer.Option("./alter_ego_db", help="ChromaDB persistence dir"),
     palette_name: str = typer.Option(DEFAULT_PALETTE, help=f"One of: {', '.join(PALETTES.keys())}")
 ):
-    cfg_path = Path("emma_config.yaml")
+    cfg_path = Path("alter_ego_config.yaml")
     cfg = load_config(cfg_path)
     cfg.data_dir = data
     cfg.db_dir = db
@@ -533,7 +533,7 @@ def init(
 
 @app.command()
 def ingest(path: str = typer.Argument(..., help="File or folder to ingest")):
-    cfg = load_config(Path("emma_config.yaml"))
+    cfg = load_config(Path("alter_ego_config.yaml"))
     banner(cfg)
     bank = MemoryBank(cfg)
     embedder = Embedder(cfg.embed_model_name)
@@ -543,7 +543,7 @@ def ingest(path: str = typer.Argument(..., help="File or folder to ingest")):
 
 @app.command("watch")
 def watch_cmd(path: str = typer.Argument(None, help="Folder to watch (defaults to config data_dir)")):
-    cfg = load_config(Path("emma_config.yaml"))
+    cfg = load_config(Path("alter_ego_config.yaml"))
     banner(cfg)
     bank = MemoryBank(cfg)
     embedder = Embedder(cfg.embed_model_name)
@@ -558,7 +558,7 @@ def ask(
     max_tokens: int = typer.Option(512),
     temperature: float = typer.Option(0.7),
 ):
-    cfg = load_config(Path("emma_config.yaml"))
+    cfg = load_config(Path("alter_ego_config.yaml"))
     if backend: cfg.llm_backend = backend
     if model_name: cfg.llm_model_name = model_name
     banner(cfg)
@@ -589,7 +589,7 @@ def ask(
 
 @app.command("scan-dupes")
 def scan_dupes_cmd():
-    cfg = load_config(Path("emma_config.yaml"))
+    cfg = load_config(Path("alter_ego_config.yaml"))
     banner(cfg)
     bank = MemoryBank(cfg)
     report = scan_dupes(cfg, bank)
@@ -637,7 +637,7 @@ def consolidate(
     strategy: str = typer.Option("newest", help="newest | oldest | keep_first"),
     only_paths: bool = typer.Option(False, help="Just print plan; don’t delete")
 ):
-    cfg = load_config(Path("emma_config.yaml"))
+    cfg = load_config(Path("alter_ego_config.yaml"))
     banner(cfg)
     bank = MemoryBank(cfg)
     report = scan_dupes(cfg, bank)
@@ -645,7 +645,7 @@ def consolidate(
 
 @app.command("list-dupes")
 def list_dupes(only_paths: bool = typer.Option(True, help="Only print paths")):
-    cfg = load_config(Path("emma_config.yaml"))
+    cfg = load_config(Path("alter_ego_config.yaml"))
     banner(cfg)
     bank = MemoryBank(cfg)
     report = scan_dupes(cfg, bank)
@@ -657,7 +657,7 @@ def list_dupes(only_paths: bool = typer.Option(True, help="Only print paths")):
 
 @app.command("suggest")
 def suggest():
-    cfg = load_config(Path("emma_config.yaml"))
+    cfg = load_config(Path("alter_ego_config.yaml"))
     banner(cfg)
     bank = MemoryBank(cfg)
     sugg = suggest_upgrades(cfg, bank)
@@ -672,7 +672,7 @@ def suggest():
 
 @app.command("config")
 def config_cmd(show: bool = typer.Option(True), set_backend: Optional[str] = None, set_model: Optional[str] = None, set_palette: Optional[str] = None):
-    cfg_path = Path("emma_config.yaml")
+    cfg_path = Path("alter_ego_config.yaml")
     cfg = load_config(cfg_path)
     changed = False
     if set_backend:

--- a/main/alter_ego_config.yaml
+++ b/main/alter_ego_config.yaml
@@ -3,7 +3,7 @@ llm_model_name: DeepSeek-R1-Distill-Qwen-1.5B-Q4_0.gguf
 
 embed_model_name: all-MiniLM-L6-v2
 
-db_path: emma_memory.db
+db_path: alter_ego_memory.db
 embedding_cache: true
 
 top_k: 5

--- a/main/alter_ego_presence.py
+++ b/main/alter_ego_presence.py
@@ -19,10 +19,10 @@ voice_engine.setProperty('rate', 165)
 voice_engine.setProperty('volume', 0.9)
 
 # === GUI App Class ===
-class EmmaGUI:
+class AlterEgoGUI:
     def __init__(self, root):
         self.root = root
-        root.title("Emma's Computer")
+        root.title("Alter/Ego")
 
         self.prompt_label = tk.Label(root, text="Talk to me:")
         self.prompt_label.pack()
@@ -64,7 +64,7 @@ class EmmaGUI:
             self.output_area.insert(tk.END, f"{whisper}\n")
             self.speak(whisper)
 
-        self.output_area.insert(tk.END, f"Emma’s Computer: {llm_reply.strip()}\n\n")
+        self.output_area.insert(tk.END, f"Alter/Ego: {llm_reply.strip()}\n\n")
         self.output_area.see(tk.END)
         self.status_label.config(text="Echo saved.")
 
@@ -76,5 +76,5 @@ class EmmaGUI:
 # === Launch GUI ===
 if __name__ == "__main__":
     root = tk.Tk()
-    app = EmmaGUI(root)
+    app = AlterEgoGUI(root)
     root.mainloop()

--- a/main/alter_shell.py
+++ b/main/alter_shell.py
@@ -22,7 +22,7 @@ class AlterShell:
         self.fronting = PersonaFronting()
 
         # SQLite DB path (override with MEMORY_DB env var)
-        self.db_path = os.getenv("MEMORY_DB", os.path.join(os.getcwd(), "emma_memory.db"))
+        self.db_path = os.getenv("MEMORY_DB", os.path.join(os.getcwd(), "alter_ego_memory.db"))
         init_db(self.db_path)
 
         # Shared LLM instance loaded in background

--- a/main/launch_alter_ego.ps1
+++ b/main/launch_alter_ego.ps1
@@ -8,10 +8,10 @@ pip install -U pip
 pip install chromadb sentence-transformers rich typer watchdog pydantic pyyaml markdown2 requests numpy scikit-learn nltk pyttsx3 gpt4all
 
 # STEP 3: First-run init (creates DB and data folders if needed)
-python alter_ego_computer.py init --data .\my_files --db .\emma_memory.db
+  python alter_ego_computer.py init --data .\my_files --db .\alter_ego_memory.db
 
 # STEP 4: Ingest core system paths (you can add more later)
-python alter_ego_computer.py ingest "C:\EdenOS_Origin\dreambearer_notes\private_notes\Emmas_Computer_AI"
+  python alter_ego_computer.py ingest "C:\EdenOS_Origin\dreambearer_notes\private_notes\Alter_Ego_AI"
 
 # STEP 5: Ask a memory-based question using GPT4All model
 python alter_ego_computer.py ask "what lives in what_the_fuck_even_is_life.chaos?" --backend gpt4all --model_name "DeepSeek-R1-Distill-Qwen-1.5B-Q4_0.gguf"
@@ -22,7 +22,7 @@ python alter_ego_computer.py scan-dupes
 # STEP 7: Set persona root and launch the GUI
 $env:PERSONA_ROOT = "C:\EdenOS_Origin\all_daemons"
 # Point to local GPT4All models directory (adjust if needed)
-$env:GPT4ALL_MODELS_DIR = "C:\Users\emmar\AppData\Local\nomic.ai\GPT4All"
+  $env:GPT4ALL_MODELS_DIR = "C:\Users\alter_ego\AppData\Local\nomic.ai\GPT4All"
 # Optional: set a specific model filename found in that directory, e.g.:
 # $env:GPT4ALL_MODEL = "DeepSeek-R1-Distill-Qwen-1.5B-Q4_0.gguf"
 # Optional: disable TTS by setting to 0

--- a/main/symbolic_config.yaml
+++ b/main/symbolic_config.yaml
@@ -7,11 +7,11 @@ default_tags:
 symbolic_paths:
   threads:
     - "C:/EdenOS_Origin"
-    - "C:/Users/emmar/Desktop/Eden_Rebuild"
+      - "C:/Users/alter_ego/Desktop/Eden_Rebuild"
   sacred: []
   tender:
     - "C:/EdenOS_Origin"
-    - "C:/Users/emmar/Desktop/Eden_Rebuild"
+      - "C:/Users/alter_ego/Desktop/Eden_Rebuild"
   unstable: []
   ignored:
     - "C:/Windows"


### PR DESCRIPTION
## Summary
- replace Emma-specific paths and strings with neutral Alter/Ego naming
- switch default database files and directories to `alter_ego_*`
- update scripts and GUI classes to use Alter/Ego branding

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'echo_whisper_layer')*

------
https://chatgpt.com/codex/tasks/task_e_68bdbcd1ab448327923e752f9c5bb04b