### PR TITLE
docs: add contributing guide and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Help us fix problems
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run '...'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots or Logs**
+If applicable, add screenshots or log snippets to help explain your problem.
+
+**Environment (please complete the following information):**
+- OS: [e.g. Windows, macOS]
+- Python version: [e.g. 3.9]
+- Commit: [e.g. abc123]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: enhancement
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing to Alter/Ego
+
+Thank you for helping shape Alter/Ego. This document describes how to set up your environment, follow the project's coding style, and run tests.
+
+## Setup
+
+1. Ensure you have **Python 3.8+** installed.
+2. Create and activate a virtual environment:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+3. Install dependencies from the `main` directory:
+   ```bash
+   pip install -r main/requirements.txt
+   ```
+
+## Coding Style
+
+- Adhere to [PEP 8](https://peps.python.org/pep-0008/).
+- Use four spaces for indentation.
+- Write clear, descriptive names for variables and functions.
+- Include docstrings for new modules, classes, and functions.
+- Keep functions focused; prefer readability over cleverness.
+
+## Tests
+
+Run the test suite from the `main` directory:
+```bash
+cd main
+PYTHONPATH=. pytest
+```
+Add tests for any new features or bug fixes. Ensure all tests pass before opening a pull request.
+
+## Issues
+
+Use the templates under `.github/ISSUE_TEMPLATE` when reporting bugs or requesting features.
+
+We appreciate your contributions—big or small.

--- a/main/README.md
+++ b/main/README.md
@@ -78,6 +78,16 @@ No internet or remote calls. Runs entirely on your machine for privacy, safety, 
 
 ---
 
+## Contributing
+
+See the [CONTRIBUTING](../CONTRIBUTING.md) guide for setup, coding style, and tests.
+
+Bug reports and feature requests can be opened via the issue templates:
+- [Bug report](../.github/ISSUE_TEMPLATE/bug_report.md)
+- [Feature request](../.github/ISSUE_TEMPLATE/feature_request.md)
+
+---
+
 ## Credits
 
 Voice and behavior inspired by fictional AI and archetypal guides from works like *Danganronpa*, *Persona*, and personal innerworld modeling.


### PR DESCRIPTION
## Summary
- add contributing guidelines with setup, style, and testing instructions
- introduce issue templates for bugs and feature requests
- link docs and templates from README

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdbcd1754c83279c662f71edb8d6b8