### PR TITLE
Mirror deps and clarify installation workflow

### DIFF
--- a/main/README.md
+++ b/main/README.md
@@ -19,10 +19,16 @@
 
 ## Quickstart
 
-1. **Install dependencies:**
+1. **Install dependencies** — Using `requirements.txt` is the recommended approach for a reproducible local setup:
 
    ```bash
    pip install -r requirements.txt
+   ```
+
+   If you prefer to use the project metadata directly, you can install via `pyproject.toml`:
+
+   ```bash
+   pip install .
    ```
 
 2. **Run the application:**

--- a/main/requirements.txt
+++ b/main/requirements.txt
@@ -1,9 +1,11 @@
-pyttsx3
-pyyaml
-openai
+chromadb
+gpt4all
+markdown2
 nltk
 numpy
-scikit-learn
-markdown2
+openai
+pyttsx3
+pyyaml
 requests
-gpt4all
+scikit-learn
+sentence-transformers


### PR DESCRIPTION
## Summary
- sync requirements.txt with pyproject dependencies
- add preferred install instructions for requirements vs pyproject

## Testing
- ⚠️ `pip install -r requirements.txt` *(partial; heavy packages cancelled)*
- ✅ `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdbcd0897083279ac6181c65a302fa