### PR TITLE
Clarify memory DB defaults

### DIFF
--- a/main/README.md
+++ b/main/README.md
@@ -56,6 +56,7 @@
 ## Storage & Persistence
 
 * **Memory Files** — Saved as `.chaos` logs using symbolic syntax
+* **Memory DB** — Embedding store in `alter_ego_memory.db`; override path with `MEMORY_DB`
 * **Personas** — Defined in `.json` and `.mirror` formats
 * **Echo Logs** — Captures emotional states, fronting history, tremor patterns
 

--- a/main/alter_shell.py
+++ b/main/alter_shell.py
@@ -21,7 +21,7 @@ class AlterShell:
         self.echo_response = AlterEchoResponse()
         self.fronting = PersonaFronting()
 
-        # SQLite DB path (override with MEMORY_DB env var)
+        # SQLite DB path (default 'alter_ego_memory.db'; override with MEMORY_DB env var)
         self.db_path = os.getenv("MEMORY_DB", os.path.join(os.getcwd(), "alter_ego_memory.db"))
         init_db(self.db_path)
 


### PR DESCRIPTION
## Summary
- document SQLite memory DB and `MEMORY_DB` env override
- clarify default `alter_ego_memory.db` path in `alter_shell`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'echo_whisper_layer')*

------
https://chatgpt.com/codex/tasks/task_e_68bdcb18bd3083278c6bb878b9bdc61d