### PR TITLE
Ensure tests see project modules

### DIFF
--- a/main/tests/conftest.py
+++ b/main/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure the 'main' directory is on the Python path for test imports
+sys.path.append(str(Path(__file__).resolve().parent.parent))


### PR DESCRIPTION
## Summary
- add `conftest.py` so pytest adds the `main` directory to `sys.path`

## Testing
- `pytest main/tests/test_echo_emotion.py -q`
- `pytest main/tests -q` *(fails: ModuleNotFoundError: No module named 'sentence_transformers')*
- `pip install sentence-transformers` *(fails: operation cancelled; large CUDA downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcb19d1208327bb7d85910d6dbfcb