### PR TITLE
Add theme directory and clarify GUI theme fallback

### DIFF
--- a/main/README.md
+++ b/main/README.md
@@ -35,7 +35,12 @@
    python alter_ego_gui.py
    ```
 
-3. **Begin interacting.** The assistant will respond with adaptive tone and whisper when it detects emotional load.
+   3. **Begin interacting.** The assistant will respond with adaptive tone and whisper when it detects emotional load.
+
+### Themes
+
+The GUI looks for JSON theme files in `themes/` relative to `alter_ego_gui.py` (or a custom path via the `THEME_DIR` environment variable).
+If no external themes are found, Alter/Ego falls back to its built-in styles such as `eden`, `dark`, and `light`.
 
 ---
 

--- a/main/alter_ego_gui.py
+++ b/main/alter_ego_gui.py
@@ -88,6 +88,7 @@ sys.stderr = _Tee(sys.stderr, _syslog_fp)
 # Config / Themes
 # =========================
 CONFIG_PATH = APP_DIR / "gui_config.json"
+# Looks for JSON themes under main/themes or THEME_DIR override
 THEME_DIR = Path(os.getenv("THEME_DIR") or (APP_DIR / "themes"))
 
 BUILTIN_THEMES: dict[str, dict] = {
@@ -293,7 +294,10 @@ class AlterEgoGUI:
 
         # Config + themes
         self.cfg = load_gui_config()
-        self.themes = load_json_themes(THEME_DIR) or BUILTIN_THEMES.copy()
+        self.themes = load_json_themes(THEME_DIR)
+        if not self.themes:
+            log.info("No JSON themes found in %s; using built-in themes", THEME_DIR)
+            self.themes = BUILTIN_THEMES.copy()
 
         # State
         self.prismari_enabled = tk.BooleanVar(value=bool(self.cfg.get("prismari_enabled", True)))

--- a/main/themes/ocean.json
+++ b/main/themes/ocean.json
@@ -1,0 +1,11 @@
+{
+  "bg": "#001a1a",
+  "text_bg": "#002e2e",
+  "text_fg": "#d0fffa",
+  "user_fg": "#03dac6",
+  "alter_fg": "#bb86fc",
+  "entry_bg": "#003d3d",
+  "entry_fg": "#eaffff",
+  "font_family": "Consolas",
+  "font_size": 12
+}


### PR DESCRIPTION
## Summary
- Introduce a `themes` directory with an example `ocean` JSON theme
- Document how the GUI loads themes and falls back to built‑ins
- Log when custom themes are missing and default styles are used

## Testing
- `PYTHONPATH=. pytest -q` *(fails: NameError: name 'FileSystemEventHandler' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcb18a9e483278532c7fc8fec5815