### PR TITLE
docs: add example CHAOS session and README snippet

### DIFF
--- a/main/README.md
+++ b/main/README.md
@@ -102,4 +102,35 @@ Bug reports and feature requests can be opened via the issue templates:
 
 Voice and behavior inspired by fictional AI and archetypal guides from works like *Danganronpa*, *Persona*, and personal innerworld modeling.
 
+### Example CHAOS Session
+
+An abbreviated session log lives in `example_session.chaos`. The full contents are mirrored below:
+
+```
+[EVENT]: session_start
+[TIME]: 2024-01-01T12:00:00Z
+[CONTEXT]: system_init
+[SIGNIFICANCE]: LOW
+{
+Session begins.
+}
+
+[EVENT]: user_prompt
+[TIME]: 2024-01-01T12:01:00Z
+[CONTEXT]: prompt_catch
+[SIGNIFICANCE]: MEDIUM
+{
+Hello, Alter/Ego.
+}
+
+[EVENT]: session_end
+[TIME]: 2024-01-01T12:05:00Z
+[CONTEXT]: system_shutdown
+[SIGNIFICANCE]: LOW
+{
+Closing session.
+}
+
+```
+
 Project scaffolding by Stratus with support from Aevum and Vox.

--- a/main/example_session.chaos
+++ b/main/example_session.chaos
@@ -1,0 +1,24 @@
+[EVENT]: session_start
+[TIME]: 2024-01-01T12:00:00Z
+[CONTEXT]: system_init
+[SIGNIFICANCE]: LOW
+{
+Session begins.
+}
+
+[EVENT]: user_prompt
+[TIME]: 2024-01-01T12:01:00Z
+[CONTEXT]: prompt_catch
+[SIGNIFICANCE]: MEDIUM
+{
+Hello, Alter/Ego.
+}
+
+[EVENT]: session_end
+[TIME]: 2024-01-01T12:05:00Z
+[CONTEXT]: system_shutdown
+[SIGNIFICANCE]: LOW
+{
+Closing session.
+}
+


### PR DESCRIPTION
## Summary
- add `example_session.chaos` with complete closing event
- mirror the example session log in the README

## Testing
- `PYTHONPATH=. pytest` *(fails: NameError: FileSystemEventHandler is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcb194b1083279c217e703339b0c8