### PR TITLE
docs: remove GUI screenshot reference

### DIFF
--- a/main/README.md
+++ b/main/README.md
@@ -37,6 +37,15 @@
 
    3. **Begin interacting.** The assistant will respond with adaptive tone and whisper when it detects emotional load.
 
+### GUI Screenshot
+
+The repository no longer ships a static `gui_screenshot.png` file. To capture the interface:
+
+1. Launch the GUI with `python alter_ego_gui.py`.
+2. Use your operating system's screenshot tool to save an image of the window.
+
+An example screenshot is available at [this externally hosted image](https://via.placeholder.com/800x600.png?text=Alter/Ego+GUI). If the link ever fades, simply capture your own.
+
 ### Themes
 
 The GUI looks for JSON theme files in `themes/` relative to `alter_ego_gui.py` (or a custom path via the `THEME_DIR` environment variable).


### PR DESCRIPTION
## Summary
- remove obsolete GUI screenshot and explain how to capture it at runtime
- mention externally hosted placeholder screenshot in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sentence_transformers')*

------
https://chatgpt.com/codex/tasks/task_e_68be1eed6ef88327b1f503fcb3e1cb8c