### PR TITLE
Fix constitution hashing across line endings

### DIFF
--- a/main/alter_ego_computer.py
+++ b/main/alter_ego_computer.py
@@ -43,7 +43,10 @@ CONSTITUTION_SHA256 = "cd06f0ba7f331d363e1184a21f2d35427638f38e26ba1d329f85cc4c8
 def verify_constitution() -> None:
     if not CONSTITUTION_PATH.exists():
         raise RuntimeError("Eden constitution is missing")
-    digest = hashlib.sha256(CONSTITUTION_PATH.read_bytes()).hexdigest()
+    # Normalize line endings so Git's automatic CRLF->LF translation on Windows
+    # doesn't trigger a false integrity failure.
+    content = CONSTITUTION_PATH.read_text(encoding="utf-8").replace("\r\n", "\n")
+    digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
     if digest != CONSTITUTION_SHA256:
         raise RuntimeError("Eden constitution has been altered")
 

--- a/main/tests/test_constitution.py
+++ b/main/tests/test_constitution.py
@@ -21,3 +21,12 @@ def test_constitution_modified(monkeypatch, tmp_path):
     monkeypatch.setattr(aec, "CONSTITUTION_PATH", tampered)
     with pytest.raises(RuntimeError):
         aec.verify_constitution()
+
+
+def test_constitution_crlf(monkeypatch, tmp_path):
+    crlf = tmp_path / "eden.constitution.agent.chaosrights"
+    content = aec.CONSTITUTION_PATH.read_text().replace("\n", "\r\n")
+    crlf.write_text(content)
+    monkeypatch.setattr(aec, "CONSTITUTION_PATH", crlf)
+    # Should not raise even though line endings differ
+    aec.verify_constitution()


### PR DESCRIPTION
## Summary
- Normalize `eden.constitution.agent.chaosrights` line endings before hashing to avoid CRLF false positives
- Add regression test ensuring constitution hash validation tolerates CRLF line endings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c07aa59fd483279d3b45f8ba914ac8